### PR TITLE
Add a script to dump XcodeCloud environment

### DIFF
--- a/XcodeCloudSampleApp.xcodeproj/project.pbxproj
+++ b/XcodeCloudSampleApp.xcodeproj/project.pbxproj
@@ -134,7 +134,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F555FF3927DBCA2900A6A2B4 /* Build configuration list for PBXNativeTarget "XcodeCloudSampleApp" */;
 			buildPhases = (
-				F555FF4227DBD2ED00A6A2B4 /* Log tooling versions */,
+				F555FF4227DBD2ED00A6A2B4 /* Show environments */,
 				F555FF1127DBCA2800A6A2B4 /* Sources */,
 				F555FF1227DBCA2800A6A2B4 /* Frameworks */,
 				F555FF1327DBCA2800A6A2B4 /* Resources */,
@@ -254,7 +254,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		F555FF4227DBD2ED00A6A2B4 /* Log tooling versions */ = {
+		F555FF4227DBD2ED00A6A2B4 /* Show environments */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -263,14 +263,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Log tooling versions";
+			name = "Show environments";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"## Xcode\" && xcodebuild -version\necho \"## Swift\" && swiftc -version\necho \"## Ruby\" && ruby --version\necho \"## Python\" && python --version\necho \"## Java\" && which java\n";
+			shellScript = "$PROJECT_DIR/scripts/environments.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/scripts/environments.sh
+++ b/scripts/environments.sh
@@ -8,10 +8,10 @@ function show_delimiter {
     echo "----------"
 }
 
-echo "## All environment variables:" && env
+log_and_run uname -a
 show_delimiter
 
-log_and_run uname -a
+log_and_run sw_vers
 show_delimiter
 
 log_and_run xcodebuild -version

--- a/scripts/environments.sh
+++ b/scripts/environments.sh
@@ -8,6 +8,9 @@ function show_delimiter {
     echo "----------"
 }
 
+log_and_run system_profiler SPHardwareDataType
+show_delimiter
+
 log_and_run uname -a
 show_delimiter
 

--- a/scripts/environments.sh
+++ b/scripts/environments.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 echo "## All environment variables:" && env
 echo "----------"
+
 echo "## Xcode version:" && xcodebuild -version
 echo "----------"
+
 echo "## Swift version:" && swiftc -version
 echo "----------"
+
 echo "## Ruby version:" && ruby --version
 echo "----------"
+
 echo "## Python version:" && python --version; python3 --version
 echo "----------"
+
 echo "## Java version:" &&  which java && java -version
 echo "----------"

--- a/scripts/environments.sh
+++ b/scripts/environments.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
+function log_and_run {
+    echo "> $@"
+    $@
+}
+
+function show_delimiter {
+    echo "----------"
+}
+
 echo "## All environment variables:" && env
-echo "----------"
+show_delimiter
 
-echo "## Xcode version:" && xcodebuild -version
-echo "----------"
+log_and_run uname -a
+show_delimiter
 
-echo "## Swift version:" && swiftc -version
-echo "----------"
+log_and_run xcodebuild -version
+show_delimiter
 
-echo "## Ruby version:" && ruby --version
-echo "----------"
+log_and_run swiftc -version
+show_delimiter
 
-echo "## Python version:" && python --version; python3 --version
-echo "----------"
+log_and_run ruby --version
+show_delimiter
 
-echo "## Java version:" &&  which java && java -version
-echo "----------"
+log_and_run python --version
+log_and_run python3 --version
+show_delimiter
+
+log_and_run which java && log_and_run java -version
+show_delimiter

--- a/scripts/environments.sh
+++ b/scripts/environments.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "## All environment variables:" && env
+echo "----------"
+echo "## Xcode version:" && xcodebuild -version
+echo "----------"
+echo "## Swift version:" && swiftc -version
+echo "----------"
+echo "## Ruby version:" && ruby --version
+echo "----------"
+echo "## Python version:" && python --version; python3 --version
+echo "----------"
+echo "## Java version:" &&  which java && java -version
+echo "----------"


### PR DESCRIPTION
- Make showing environment a separate script
- run `system_profiler SPHardwareDataType`, `uname -a` and `sw_vers` in the script as well

This is the sample of the output. cc: @bachand 

```
> system_profiler SPHardwareDataType
Hardware:

    Hardware Overview:

      Model Name: Mac
      Model Identifier: MacVM1,1
      Processor Name: Unknown
      Processor Speed: 2 GHz
      Number of Processors: 4
      Total Number of Cores: 4
      L2 Cache (per Processor): 4 MB
      L3 Cache (per Processor): 16 MB
      Memory: 16 GB
      System Firmware Version: AVM11.88Z.0003.D00.2110230656
      OS Loader Version: 540.100.7~14
      SMC Version (system): 1.13f3
      Serial Number (system): SW-UYYCHIG8NQTA5CL6YYOWM7
      Hardware UUID: 1A421A68-CE31-4960-9204-D5C13B70EC26
      Provisioning UDID: 1A421A68-CE31-4960-9204-D5C13B70EC26

----------
> uname -a
Darwin locals-Mac.local 21.4.0 Darwin Kernel Version 21.4.0: Mon Feb 21 20:34:37 PST 2022; root:xnu-8020.101.4~2/RELEASE_X86_64 x86_64
----------
> sw_vers
ProductName:	macOS
ProductVersion:	12.3
BuildVersion:	21E230
----------
> xcodebuild -version
Xcode 13.3
Build version 13E113
----------
> swiftc -version
swift-driver version: 1.45.2 
<unknown>:0: warning: using sysroot for 'iPhoneOS' but targeting 'MacOSX'
Apple Swift version 5.6 (swiftlang-5.6.0.323.62 clang-1316.0.20.8)
Target: x86_64-apple-macosx12.0
----------
> ruby --version
ruby 2.6.8p205 (2021-07-07 revision 67951) [universal.x86_64-darwin21]
----------
> python --version
/Volumes/workspace/repository/scripts/environments.sh: line 4: python: command not found
> python3 --version
Python 3.8.9
----------
> which java
/usr/bin/java
> java -version
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.

----------
```